### PR TITLE
Fix the mistake of omitting curly brackets

### DIFF
--- a/core/decode.cpp
+++ b/core/decode.cpp
@@ -388,14 +388,17 @@ int decodeframe(int frame_num, d2vcontext *ctx, decodecontext *dctx, AVFrame *ou
      * Set it to the stream that matches our MPEG-TS PID if applicable.
      */
     if (dctx->stream_index == -1) {
-        if (ctx->ts_pid)
+        if (ctx->ts_pid) {
             for(i = 0; i < dctx->fctx->nb_streams; i++)
                 if (dctx->fctx->streams[i]->id == ctx->ts_pid)
                     break;
-        else
+        } else {
             for(i = 0; i < dctx->fctx->nb_streams; i++)
                 if (dctx->fctx->streams[i]->codec->codec_type == AVMEDIA_TYPE_VIDEO)
                     break;
+        }
+        if (i >= dctx->fctx->nb_streams)
+            goto dfail;
 
         dctx->stream_index = (int) i;
     }


### PR DESCRIPTION
This is fix patch of hang-up problem.

Maybe, this is the cause of this problem.
http://forum.doom9.org/showpost.php?p=1604672&postcount=50

> Bad news. The GCC Beta4 build seems to be broken. It just hangs when I try to load it. MSVC Beta4 build works fine.
