### PR TITLE
Add check to GetFrame function to handle a frame number greater than total number of frames

### DIFF
--- a/vs/d2vsource.cpp
+++ b/vs/d2vsource.cpp
@@ -50,6 +50,10 @@ const VSFrameRef *VS_CC d2vGetFrame(int n, int activationReason, void **instance
     /* Unreference the previously decoded frame. */
     av_frame_unref(d->frame);
 
+    if (n >= d->d2v->frames.size()) {
+        n = d->d2v->frames.size() - 1;
+    }
+
     ret = decodeframe(n, d->d2v, d->dec, d->frame, msg);
     if (ret < 0) {
         vsapi->setFilterError(msg.c_str(), frameCtx);


### PR DESCRIPTION
This will allow handling a case where a GetFrame request may be for a frame number greater than the total number of frames. It will simply set n to the last frame and return that. This came up out of the issue discussed starting here: http://forum.doom9.org/showthread.php?p=1653750#post1653750
