### PR TITLE
Add range limit to n to handle less than 0 and greater than numFrames

### DIFF
--- a/vs/d2vsource.cpp
+++ b/vs/d2vsource.cpp
@@ -47,6 +47,9 @@ const VSFrameRef *VS_CC d2vGetFrame(int n, int activationReason, void **instance
     string msg;
     int ret;
 
+    // Range limit n
+    n  = (n < 0) ? 0 : (n>= d->vi->numFrames) ? d->vi->numFrames -1 : n;
+
     /* Unreference the previously decoded frame. */
     av_frame_unref(d->frame);
 


### PR DESCRIPTION
Add check for n being less than 0 or greater than numFrames.  Came out of an issue discussed here: http://forum.doom9.org/showthread.php?p=1653750#post1653750
