### PR TITLE
Fix compilation on Linux and minior tweak

### DIFF
--- a/configure
+++ b/configure
@@ -172,8 +172,8 @@ fi
 if cc_check "-Os -ffast-math $CXXFLAGS" "$LDFLAGS"; then
     CXXFLAGS="-Os -ffast-math $CXXFLAGS"
 fi
-if cc_check "$CXXFLAGS -fexcess-precision=fast" "$LDFLAGS"; then
-    CXXFLAGS="$CXXFLAGS -fexcess-precision=fast"
+if cc_check "$CXXFLAGS" "$LDFLAGS"; then
+    CXXFLAGS="$CXXFLAGS"
 fi
 
 PKGCONFIGBIN="pkg-config"
@@ -222,7 +222,7 @@ fi
 
 LDFLAGS="$SOFLAGS $LDFLAGS"
 LIBS="$LIBS $XLIBS"
-
+CXXFLAGS="$CXXFLAGS $VSCFLAGS"
 
 cat >> config.mak << EOF
 CXX = $CXX


### PR DESCRIPTION
- Actually use pkg-config output to determine vapoursynth's header location.
- Remove compiler option ```-fexcess-precision=fast``` because it is completely useless in this scope and incompatible with clang.