### PR TITLE
d2v: Get rid of ifstream

### DIFF
--- a/src/core/compat.cpp
+++ b/src/core/compat.cpp
@@ -20,26 +20,29 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <fstream>
+#include <stdio.h>
 #include <string>
 
 #include "compat.hpp"
 
 using namespace std;
 
-/* Replacement function for getline that removes any trailing \r. */
-istream& d2vgetline(istream& is, string& str)
+void d2vgetline(FILE *f, string& str)
 {
-    string tmp;
-
     str.clear();
 
-    getline(is, tmp);
+    while (1) {
+        int ch = fgetc(f);
 
-    if (tmp.size() != 0 && tmp.at(tmp.length() - 1) == 0x0D)
-        tmp.erase(tmp.length() - 1);
+        if (ch == EOF)
+            break;
 
-    str = tmp;
+        if (ch == '\n') {
+            if (str[str.size() - 1] == '\r')
+                str.erase(str.size() - 1, 1);
+            break;
+        }
 
-    return is;
+        str += (char)ch;
+    }
 }

--- a/src/core/compat.hpp
+++ b/src/core/compat.hpp
@@ -23,7 +23,7 @@
 #ifndef COMPAT_H
 #define COMPAT_H
 
-#include <fstream>
+#include <stdio.h>
 #include <string>
 
 /* Large file aware functions. */
@@ -43,6 +43,6 @@
 
 using namespace std;
 
-istream& d2vgetline(istream& is, string& str);
+void d2vgetline(FILE *f, string& str);
 
 #endif

--- a/src/core/d2v.cpp
+++ b/src/core/d2v.cpp
@@ -20,7 +20,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <fstream>
 #include <iostream>
 #include <string>
 #include <sstream>
@@ -28,6 +27,7 @@
 
 extern "C" {
 #include <assert.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 }
@@ -86,7 +86,7 @@ void d2vfreep(d2vcontext **ctx)
 d2vcontext *d2vparse(const char *filename, string& err)
 {
     string line;
-    ifstream input;
+    FILE *input = NULL;
     d2vcontext *ret;
     int i;
 
@@ -108,12 +108,12 @@ d2vcontext *d2vparse(const char *filename, string& err)
         goto fail;
     }
 
-    input.open(wide_filename);
+    input = _wfopen(wide_filename, L"rb");
 #else
-    input.open(filename);
+    input = fopen(filename, "rb");
 #endif
 
-    if (input.fail()) {
+    if (!input) {
         err = "D2V cannot be opened.";
         goto fail;
     }
@@ -278,7 +278,8 @@ d2vcontext *d2vparse(const char *filename, string& err)
         d2vgetline(input, line);
     }
 
-    input.close();
+    fclose(input);
+    input = NULL;
 
     if (!ret->frames.size() || !ret->gops.size()) {
         err = "No frames in D2V file!";
@@ -289,5 +290,7 @@ d2vcontext *d2vparse(const char *filename, string& err)
 
 fail:
     d2vfreep(&ret);
+    if (input)
+        fclose(input);
     return NULL;
 }


### PR DESCRIPTION
This makes it possible to compile with GCC, as
ifstream::open(const wchar_t *) is a Microsoft extension that libstdc++
doesn't have.