### PR TITLE
Fix _ColorRange, it's the wrong way around!

### DIFF
--- a/src/vs/d2vsource.cpp
+++ b/src/vs/d2vsource.cpp
@@ -104,9 +104,9 @@ const VSFrameRef *VS_CC d2vGetFrame(int n, int activationReason, void **instance
      * _ColorRange describes the input range.
      */
     if (d->d2v->yuvrgb_scale == PC)
-        vsapi->propSetInt(props, "_ColorRange", 1, paReplace);
-    else if (d->d2v->yuvrgb_scale == TV)
         vsapi->propSetInt(props, "_ColorRange", 0, paReplace);
+    else if (d->d2v->yuvrgb_scale == TV)
+        vsapi->propSetInt(props, "_ColorRange", 1, paReplace);
 
     switch (d->frame->pict_type) {
     case AV_PICTURE_TYPE_I:


### PR DESCRIPTION
Fixes: https://github.com/dwbuiten/d2vsource/issues/40

DGIndex sets the "YUVRGB_Scale" in the D2V file as follows:
- 0 == TV == Limited
- 1 == PC == Full
http://rationalqm.us/dgmpgdec/DGIndexManual.html#YUVtoRGB

And VapourSynth reads _ColorRange as follows:
- 0 == PC == full
- 1 == TV == limited
http://www.vapoursynth.com/doc/apireference.html#reserved-frame-properties

but `core.d2v.Source` was setting it the wrong way around, this can be considered a fairly big issue.