### PR TITLE
Fix invalid read when reading a d2v file

### DIFF
--- a/src/core/compat.cpp
+++ b/src/core/compat.cpp
@@ -38,7 +38,7 @@ void d2vgetline(FILE *f, string& str)
             break;
 
         if (ch == '\n') {
-            if (str[str.size() - 1] == '\r')
+            if (str.size() && str[str.size() - 1] == '\r')
                 str.erase(str.size() - 1, 1);
             break;
         }


### PR DESCRIPTION
Happens with d2v files that have Unix-style line endings, I guess.

==947691== Invalid read of size 1
==947691==    at 0x99F6980: d2vgetline

==947691==  Address 0x12e3e39f is 1 bytes before a block of size 31 alloc'd
==947691==    at 0x483EDEF: operator new(unsigned long) (vg_replace_malloc.c:342)
==947691==    by 0x49DA0FE: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_mutate(unsigned long, unsigned long, char const*, unsigned long) (basic_string.tcc:317)