### PR TITLE
fix build due missing headers

### DIFF
--- a/src/core/d2v.cpp
+++ b/src/core/d2v.cpp
@@ -32,6 +32,7 @@
 
 #include "compat.hpp"
 #include "d2v.hpp"
+#include <memory>
 #include "gop.hpp"
 
 #ifdef _WIN32

--- a/src/core/decode.cpp
+++ b/src/core/decode.cpp
@@ -32,6 +32,7 @@ extern "C" {
 #include <cstdio>
 
 #include "compat.hpp"
+#include <memory>
 #include "d2v.hpp"
 #include "decode.hpp"
 #include "gop.hpp"


### PR DESCRIPTION
fi not:

~~~bash
  CXX      src/vs4/vapoursynth4.lo
../d2vsource/src/core/decode.cpp: In function 'decodecontext* decodeinit(d2vcontext*, int, std::string&)':
../d2vsource/src/core/decode.cpp:147:10: error: 'unique_ptr' is not a member of 'std'
  147 |     std::unique_ptr<decodecontext> ret(new decodecontext());
      |          ^~~~~~~~~~
../d2vsource/src/core/decode.cpp:37:1: note: 'std::unique_ptr' is defined in header '<memory>'; did you forget to '#include <memory>'?
   36 | #include "decode.hpp"
  +++ |+#include <memory>
   37 | #include "gop.hpp"
../d2vsource/src/core/decode.cpp:147:34: error: expected primary-expression before '>' token
  147 |     std::unique_ptr<decodecontext> ret(new decodecontext());
      |                                  ^
../d2vsource/src/core/decode.cpp:147:36: error: 'ret' was not declared in this scope
  147 |     std::unique_ptr<decodecontext> ret(new decodecontext());
      |                                    ^~~
../d2vsource/src/core/d2v.cpp: In function 'd2vcontext* d2vparse(const char*, std::string&)':
../d2vsource/src/core/d2v.cpp:64:10: error: 'unique_ptr' is not a member of 'std'
   64 |     std::unique_ptr<d2vcontext> ret(new d2vcontext());
      |          ^~~~~~~~~~
../d2vsource/src/core/d2v.cpp:35:1: note: 'std::unique_ptr' is defined in header '<memory>'; did you forget to '#include <memory>'?
   34 | #include "d2v.hpp"
  +++ |+#include <memory>
   35 | #include "gop.hpp"
../d2vsource/src/core/d2v.cpp:64:31: error: expected primary-expression before '>' token
   64 |     std::unique_ptr<d2vcontext> ret(new d2vcontext());
      |                               ^
../d2vsource/src/core/d2v.cpp:64:33: error: 'ret' was not declared in this scope
   64 |     std::unique_ptr<d2vcontext> ret(new d2vcontext());
      |                                 ^~~
../d2vsource/src/core/d2v.cpp:82:10: error: 'unique_ptr' is not a member of 'std'
   82 |     std::unique_ptr<FILE, decltype(&fclose)> input(fopen(filename, "rb"), &fclose);
      |          ^~~~~~~~~~
../d2vsource/src/core/d2v.cpp:82:10: note: 'std::unique_ptr' is defined in header '<memory>'; did you forget to '#include <memory>'?
../d2vsource/src/core/d2v.cpp:82:25: error: expected primary-expression before ',' token
   82 |     std::unique_ptr<FILE, decltype(&fclose)> input(fopen(filename, "rb"), &fclose);
      |                         ^
../d2vsource/src/core/d2v.cpp:82:27: error: expected primary-expression before 'decltype'
   82 |     std::unique_ptr<FILE, decltype(&fclose)> input(fopen(filename, "rb"), &fclose);
      |                           ^~~~~~~~~~~~~~~~~
../d2vsource/src/core/d2v.cpp:85:10: error: 'input' was not declared in this scope; did you mean 'int'?
   85 |     if (!input) {
      |          ^~~~~
      |          int
../d2vsource/src/core/d2v.cpp:91:16: error: 'input' was not declared in this scope; did you mean 'int'?
   91 |     d2vgetline(input.get(), line);
      |                ^~~~~
      |                int
make: *** [Makefile:585: src/core/decode.lo] Error 1
make: *** Waiting for unfinished jobs....
make: *** [Makefile:585: src/core/d2v.lo] Error 1
~~~

in newffmpeg branch