### PR TITLE
Remove force std namespace in headers

### DIFF
--- a/src/core/compat.cpp
+++ b/src/core/compat.cpp
@@ -25,9 +25,7 @@
 
 #include "compat.hpp"
 
-using namespace std;
-
-void d2vgetline(FILE *f, string& str)
+void d2vgetline(FILE *f, std::string& str)
 {
     str.clear();
 

--- a/src/core/compat.hpp
+++ b/src/core/compat.hpp
@@ -41,8 +41,6 @@
 #define PATH_DELIM 0x2F
 #endif
 
-using namespace std;
-
-void d2vgetline(FILE *f, string& str);
+void d2vgetline(FILE *f, std::string& str);
 
 #endif

--- a/src/core/d2v.cpp
+++ b/src/core/d2v.cpp
@@ -39,12 +39,10 @@
 #include <windows.h>
 #endif
 
-using namespace std;
-
-static string d2vgetpath(const char *d2v_path, const string& file)
+static std::string d2vgetpath(const char *d2v_path, const std::string& file)
 {
-    string path;
-    string d2v       = d2v_path;
+    std::string path;
+    std::string d2v       = d2v_path;
     size_t delim_pos = d2v.rfind(PATH_DELIM) + 1;
 
     if ((file.substr(0, 1) == "/" || file.substr(1, 1) == ":") || (d2v.substr(0, 1) != "/" && d2v.substr(1, 1) != ":")) {
@@ -58,9 +56,9 @@ static string d2vgetpath(const char *d2v_path, const string& file)
 }
 
 /* Parse the entire D2V index and build the GOP and frame lists. */
-d2vcontext *d2vparse(const char *filename, string& err)
+d2vcontext *d2vparse(const char *filename, std::string& err)
 {
-    string line;
+    std::string line;
 
     std::unique_ptr<d2vcontext> ret(new d2vcontext());
 
@@ -128,8 +126,8 @@ d2vcontext *d2vparse(const char *filename, string& err)
     d2vgetline(input.get(), line);
     while(line.length()) {
         size_t mid = line.find("=");
-        string l   = line.substr(0, mid);
-        string r   = line.substr(mid + 1, line.length() - 1);
+        std::string l   = line.substr(0, mid);
+        std::string r   = line.substr(mid + 1, line.length() - 1);
 
         if (l == "Stream_Type") {
             int type = atoi(r.c_str());
@@ -202,23 +200,23 @@ d2vcontext *d2vparse(const char *filename, string& err)
     int i = 0;
     d2vgetline(input.get(), line);
     while(line.length()) {
-        istringstream ss(line);
+        std::istringstream ss(line);
         gop cur_gop = {};
 
-        ss >> hex >> cur_gop.info;
-        ss >> dec >> cur_gop.matrix;
-        ss >> dec >> cur_gop.file;
-        ss >> dec >> cur_gop.pos;
-        ss >> dec >> cur_gop.skip;
-        ss >> dec >> cur_gop.vob;
-        ss >> dec >> cur_gop.cell;
+        ss >> std::hex >> cur_gop.info;
+        ss >> std::dec >> cur_gop.matrix;
+        ss >> std::dec >> cur_gop.file;
+        ss >> std::dec >> cur_gop.pos;
+        ss >> std::dec >> cur_gop.skip;
+        ss >> std::dec >> cur_gop.vob;
+        ss >> std::dec >> cur_gop.cell;
 
         int offset = 0;
         while(!ss.eof()) {
             uint16_t flags;
             frame f;
 
-            ss >> hex >> flags;
+            ss >> std::hex >> flags;
 
             /*
              * We have to use a 16-bit int to force the stringstream to

--- a/src/core/d2v.hpp
+++ b/src/core/d2v.hpp
@@ -34,8 +34,6 @@ extern "C" {
 
 #define D2V_VERSION "16"
 
-using namespace std;
-
 enum streamtype {
     UNSET      = -1,
     ELEMENTARY = 0,
@@ -81,7 +79,7 @@ typedef struct location {
 
 typedef struct d2vcontext {
     int num_files;
-    vector<string> files;
+    std::vector<std::string> files;
 
     enum streamtype stream_type;
     int ts_pid;
@@ -94,10 +92,10 @@ typedef struct d2vcontext {
     int fps_den;
     location loc;
 
-    vector<frame> frames;
-    vector<gop> gops;
+    std::vector<frame> frames;
+    std::vector<gop> gops;
 } d2vcontext;
 
-d2vcontext *d2vparse(const char *filename, string& err);
+d2vcontext *d2vparse(const char *filename, std::string& err);
 
 #endif

--- a/src/core/decode.cpp
+++ b/src/core/decode.cpp
@@ -41,8 +41,6 @@ extern "C" {
 #include <windows.h>
 #endif
 
-using namespace std;
-
 /*
  * AVIO seek function to handle GOP offsets and multi-file support
  * in libavformat without it knowing about it.
@@ -92,7 +90,7 @@ static int64_t file_seek(void *opaque, int64_t offset, int whence)
     }
     default:
         /* Shouldn't need to support anything else for our use case. */
-        cout << "Unsupported seek!" << endl;
+        std::cout << "Unsupported seek!" << std::endl;
         return -1;
     }
 }
@@ -143,7 +141,7 @@ decodecontext::~decodecontext()
 }
 
 /* Initialize everything we can with regards to decoding */
-decodecontext *decodeinit(d2vcontext *dctx, int threads, string& err)
+decodecontext *decodeinit(d2vcontext *dctx, int threads, std::string& err)
 {
     std::unique_ptr<decodecontext> ret(new decodecontext());
 
@@ -246,7 +244,7 @@ decodecontext *decodeinit(d2vcontext *dctx, int threads, string& err)
     return ret.release();
 }
 
-int decodeframe(int frame_num, d2vcontext *ctx, decodecontext *dctx, AVFrame *out, string& err)
+int decodeframe(int frame_num, d2vcontext *ctx, decodecontext *dctx, AVFrame *out, std::string& err)
 {
     bool next = true;
 

--- a/src/core/decode.hpp
+++ b/src/core/decode.hpp
@@ -31,8 +31,8 @@ extern "C" {
 #include <cstdint>
 
 typedef struct decodecontext {
-    vector<FILE *> files;
-    vector<int64_t> file_sizes;
+    std::vector<FILE *> files;
+    std::vector<int64_t> file_sizes;
 
     AVCodecContext *avctx;
     AVFormatContext *fctx;
@@ -54,7 +54,7 @@ typedef struct decodecontext {
     ~decodecontext();
 } decodecontext;
 
-decodecontext *decodeinit(d2vcontext *dctx, int threads, string& err);
-int decodeframe(int frame, d2vcontext *ctx, decodecontext *dctx, AVFrame *out, string& err);
+decodecontext *decodeinit(d2vcontext *dctx, int threads, std::string& err);
+int decodeframe(int frame, d2vcontext *ctx, decodecontext *dctx, AVFrame *out, std::string& err);
 
 #endif

--- a/src/core/gop.hpp
+++ b/src/core/gop.hpp
@@ -36,8 +36,6 @@
 #define FRAME_FLAG_PROGRESSIVE 0x40
 #define FRAME_FLAG_DECODABLE_WITHOUT_PREVIOUS_GOP 0x80
 
-using namespace std;
-
 typedef struct frame {
     int gop;
     int offset;
@@ -51,7 +49,7 @@ typedef struct gop {
     int skip;
     int vob;
     int cell;
-    vector<uint8_t> flags;
+    std::vector<uint8_t> flags;
 } gop;
 
 #endif

--- a/src/vs/applyrff.cpp
+++ b/src/vs/applyrff.cpp
@@ -60,8 +60,8 @@ static const VSFrameRef *VS_CC rffGetFrame(int n, int activationReason, void **i
         if (samefields) {
             vsapi->requestFrameFilter(top, d->node, frameCtx);
         } else {
-            vsapi->requestFrameFilter(min(top, bottom), d->node, frameCtx);
-            vsapi->requestFrameFilter(max(top, bottom), d->node, frameCtx);
+            vsapi->requestFrameFilter(std::min(top, bottom), d->node, frameCtx);
+            vsapi->requestFrameFilter(std::max(top, bottom), d->node, frameCtx);
         }
         return NULL;
     }
@@ -132,10 +132,10 @@ static void VS_CC rffFree(void *instanceData, VSCore *core, const VSAPI *vsapi)
 
 void VS_CC rffCreate(const VSMap *in, VSMap *out, void *userData, VSCore *core, const VSAPI *vsapi)
 {
-    string msg;
+    std::string msg;
 
     /* Allocate our private data. */
-    unique_ptr<rffData> data(new rffData());
+    std::unique_ptr<rffData> data(new rffData());
 
     /* Parse the D2V to get flags. */
     data->d2v.reset(d2vparse(vsapi->propGetData(in, "d2v", 0, 0), msg));

--- a/src/vs/applyrff.hpp
+++ b/src/vs/applyrff.hpp
@@ -41,8 +41,8 @@ typedef struct rffField {
 } rffField;
 
 typedef struct rffData {
-    unique_ptr<d2vcontext> d2v;
-    vector<rffField> fields; // Output fields, in the order they are to be displayed.
+    std::unique_ptr<d2vcontext> d2v;
+    std::vector<rffField> fields; // Output fields, in the order they are to be displayed.
 
     VSVideoInfo vi;
     VSNodeRef *node;

--- a/src/vs/d2vsource.cpp
+++ b/src/vs/d2vsource.cpp
@@ -49,7 +49,7 @@ static const VSFrameRef *VS_CC d2vGetFrame(int n, int activationReason, void **i
 {
     d2vData *d = (d2vData *) *instanceData;
     VSFrameRef *f;
-    string msg;
+    std::string msg;
 
     /* Unreference the previously decoded frame. */
     av_frame_unref(d->frame);
@@ -134,7 +134,7 @@ static void VS_CC d2vFree(void *instanceData, VSCore *core, const VSAPI *vsapi)
 
 void VS_CC d2vCreate(const VSMap *in, VSMap *out, void *userData, VSCore *core, const VSAPI *vsapi)
 {
-    string msg;
+    std::string msg;
     int err;
 
     /* Need to get thread info before anything to pass to decodeinit(). */

--- a/src/vs/d2vsource.hpp
+++ b/src/vs/d2vsource.hpp
@@ -31,8 +31,8 @@
 #include "decode.hpp"
 
 typedef struct d2vData {
-    unique_ptr<d2vcontext> d2v;
-    unique_ptr<decodecontext> dec;
+    std::unique_ptr<d2vcontext> d2v;
+    std::unique_ptr<decodecontext> dec;
     AVFrame *frame;
     VSVideoInfo vi;
     VSCore *core;

--- a/src/vs4/applyrff4.cpp
+++ b/src/vs4/applyrff4.cpp
@@ -56,8 +56,8 @@ static const VSFrame *VS_CC rffGetFrame(int n, int activationReason, void *insta
         if (samefields) {
             vsapi->requestFrameFilter(top, d->node, frameCtx);
         } else {
-            vsapi->requestFrameFilter(min(top, bottom), d->node, frameCtx);
-            vsapi->requestFrameFilter(max(top, bottom), d->node, frameCtx);
+            vsapi->requestFrameFilter(std::min(top, bottom), d->node, frameCtx);
+            vsapi->requestFrameFilter(std::max(top, bottom), d->node, frameCtx);
         }
         return NULL;
     }
@@ -128,10 +128,10 @@ static void VS_CC rffFree(void *instanceData, VSCore *core, const VSAPI *vsapi)
 
 void VS_CC rffCreate(const VSMap *in, VSMap *out, void *userData, VSCore *core, const VSAPI *vsapi)
 {
-    string msg;
+    std::string msg;
 
     /* Allocate our private data. */
-    unique_ptr<rffData> data(new rffData());
+    std::unique_ptr<rffData> data(new rffData());
 
     /* Parse the D2V to get flags. */
     data->d2v.reset(d2vparse(vsapi->mapGetData(in, "d2v", 0, 0), msg));

--- a/src/vs4/applyrff4.hpp
+++ b/src/vs4/applyrff4.hpp
@@ -43,8 +43,8 @@ typedef struct rffField {
 } rffField;
 
 typedef struct rffData {
-    unique_ptr<d2vcontext> d2v;
-    vector<rffField> fields; // Output fields, in the order they are to be displayed.
+    std::unique_ptr<d2vcontext> d2v;
+    std::vector<rffField> fields; // Output fields, in the order they are to be displayed.
 
     VSVideoInfo vi;
     VSNode *node;

--- a/src/vs4/d2vsource4.cpp
+++ b/src/vs4/d2vsource4.cpp
@@ -43,7 +43,7 @@ d2vData::~d2vData() {
 static const VSFrame *VS_CC d2vGetVSFrame(int n, d2vData *d,
     VSFrameContext *frameCtx, VSCore *core, const VSAPI *vsapi) {
     VSFrame *f;
-    string msg;
+    std::string msg;
 
     /* Unreference the previously decoded frame. */
     av_frame_unref(d->frame);
@@ -151,7 +151,7 @@ static void VS_CC d2vFree(void *instanceData, VSCore *core, const VSAPI *vsapi)
 
 void VS_CC d2vCreate(const VSMap *in, VSMap *out, void *userData, VSCore *core, const VSAPI *vsapi)
 {
-    string msg;
+    std::string msg;
     int err;
 
     /* Need to get thread info before anything to pass to decodeinit(). */

--- a/src/vs4/d2vsource4.hpp
+++ b/src/vs4/d2vsource4.hpp
@@ -33,8 +33,8 @@
 namespace vs4 {
 
 typedef struct d2vData {
-    unique_ptr<d2vcontext> d2v;
-    unique_ptr<decodecontext> dec;
+    std::unique_ptr<d2vcontext> d2v;
+    std::unique_ptr<decodecontext> dec;
     AVFrame *frame;
     VSVideoInfo vi;
     VSCore *core;


### PR DESCRIPTION
Simple PR which explicitly uses std to remove ambiguity, which, for one, breaks mingw compilation.